### PR TITLE
Correct malapropism in name for Arelion

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -1,6 +1,6 @@
 name,type,details,status,asn,rank
 Lumen,transit,signed + filtering,safe,3356,1
-Arelion (Formally Telia),transit,signed + filtering,safe,1299,2
+Arelion (formerly Telia),transit,signed + filtering,safe,1299,2
 Cogent,transit,signed + filtering,safe,174,3
 NTT,transit,signed + filtering,safe,2914,4
 Sparkle,transit,started,unsafe,6762,5


### PR DESCRIPTION
Arelion is _formerly_ Telia, not "formally" Telia. Formally means in a "formal" manner, while the correct "formerly" means previously. In the case of Arelion/Telia, this is a rebrand and the entity previously known as "Telia Carrier" is now officially Arelion Sweden AB.

This malapropism was introduced in #600.